### PR TITLE
Fix for https://github.com/dmachard/python-dnsdist-console/issues/4

### DIFF
--- a/dnsdist_console/statistics.py
+++ b/dnsdist_console/statistics.py
@@ -36,16 +36,28 @@ class Statistics:
         svr_hdr = o_list[0]
         
         svr_stats = []
+        headers = re.sub('\s+', ' ', svr_hdr).split(' ')
+
+        # Validate expectations about fields
+        if 'Name' not in headers:
+            raise ValueError("Missing Name field in dnsdist showServers()")
+        if headers[0] != '#':
+            raise ValueError("Unexpected first header in dnsdist showServers()")
+
         for s in o_list[1:]:
-            svr = {}
-            i = 0
-            j = 0
-            for i in range(len(svr_hdr)):
-                if i == len(svr_hdr)-1:
-                    svr[svr_hdr[j:].strip().lower()] = s[j:].strip()
-                if svr_hdr[i].isupper():
-                    svr[svr_hdr[j:i].strip().lower()] = s[j:i].strip()
-                    j = i        
+            # Find out the server name, expect it at pos 0
+            server_id = s.split(' ')[0]
+            srv_name_o = self.c.send_command(cmd="getServer("+server_id+")")
+            srv_name = srv_name_o.rstrip()
+            # The name output by showServers() is limited to 20 chars
+            srv_name_trunc = srv_name[:20]
+            # Sub with a copy that removes spaces to allow spliting the other fields
+            srv_name_nowsp = srv_name_trunc.replace(' ','_')
+            s = s.replace(srv_name_trunc, srv_name_nowsp)
+            # Split, except the last fields (Pools), which contains spaces too
+            svr = dict(zip(headers, re.sub('\s+', ' ', s).split(' ', len(headers) - 1)))
+            # Restore name as output by showServers()
+            svr['Name'] = srv_name_trunc
             svr_stats.append(svr)
             
         self.__stats__["backends"] = svr_stats


### PR DESCRIPTION
Parsing the server data based on the header position can lead to truncating values, at least for the Queries counter which is truncated once it reaches 10000000.

The output is space separated, but contains values that can also contain spaces (currently, the server name and pool), making splitting unreliable. The pool name is output last and spaces in that value don't alter the split. The server name is output second. To find out if the server name contains spaces, it is retrieved using getServer(); however the value output by showServer() is truncated when longer than 20 chars.

This method of parsing will stop working if additional values containing spaces are added to the output, or if the server id or pool move to a different position.