### PR TITLE
ADD support for ipv6-console access

### DIFF
--- a/dnsdist_console/console.py
+++ b/dnsdist_console/console.py
@@ -5,6 +5,9 @@ import libnacl.utils
 import struct
 import base64
 
+from dnsdist_console import util
+
+
 class Console:
     def __init__(self, key, host="127.0.0.1", port=5199):
         """authenticator class"""
@@ -46,7 +49,10 @@ class Console:
     def connect_to(self):
         """connect to console"""
         # prepare socket
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if util.is_ipv4_address(self.console_host):
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        else:
+            self.sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self.sock.settimeout(self.sock_timeout)
 

--- a/dnsdist_console/util.py
+++ b/dnsdist_console/util.py
@@ -1,0 +1,9 @@
+from ipaddress import IPv4Address
+
+
+def is_ipv4_address(addr: str) -> bool:
+    try:
+        IPv4Address(addr)
+        return True
+    except ValueError:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 libnacl==2.1.0
 scrypt==0.8.24
+ipaddress==1.0.23

--- a/tests/dnsdist.conf
+++ b/tests/dnsdist.conf
@@ -1,6 +1,7 @@
 setLocal('0.0.0.0:5553')
 
 controlSocket('0.0.0.0:5199')
+controlSocket('[::]:5199')
 setConsoleACL('0.0.0.0/0')
 
 setKey('GQpEpQoIuzA6kzgwDokX9JcXPXFvO1Emg1wAXToJ0ag=')

--- a/tests/dnsdist.conf
+++ b/tests/dnsdist.conf
@@ -1,8 +1,8 @@
 setLocal('0.0.0.0:5553')
 
-controlSocket('0.0.0.0:5199')
 controlSocket('[::]:5199')
 setConsoleACL('0.0.0.0/0')
+addConsoleACL('::/0')
 
 setKey('GQpEpQoIuzA6kzgwDokX9JcXPXFvO1Emg1wAXToJ0ag=')
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -14,3 +14,18 @@ class TestConnect(unittest.TestCase):
         
         o = self.console.send_command(cmd="showVersion()")
         self.assertRegex(o, ".*dnsdist.*")
+
+
+class TestConnectV6(unittest.TestCase):
+    def setUp(self):
+        self.console = Console(host="::1", port=5199,
+                               key="GQpEpQoIuzA6kzgwDokX9JcXPXFvO1Emg1wAXToJ0ag=")
+
+    def tearDown(self):
+        self.console.disconnect()
+
+    def test_show_version(self):
+        """connect and get version"""
+
+        o = self.console.send_command(cmd="showVersion()")
+        self.assertRegex(o, ".*dnsdist.*")


### PR DESCRIPTION
The current implementation does not allow to connect to a dnsdist-console listening only on v6. 
This Patch checks whether the given address is a v4 or v6 address and creates the correct socket.

Feel free to add any suggestions for further changes :)